### PR TITLE
Fix group by in explain other

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -46,7 +46,7 @@
               </ul>
           </header>
           <div class="container">
-            
+
             <div ng-include="'views/searchResults.html'"></div>
             <div ng-controller="StartUrlCtrl" ng-show="currSearch.state === currSearch.NO_SEARCH" ng-include="'views/startUrl.html'"></div>
           </div>
@@ -56,7 +56,7 @@
           </div>
       </div>
       <div class="east-slider">
-      </div>    
+      </div>
       <div class="pane_east">
           <h3>Search Controls</h3>
           <form class="form-horizontal" role="form" ng-controller="SolrSettingsCtrl" ng-submit="searchSettings.publishSearcher()">
@@ -78,7 +78,7 @@
               Search Args <span ng-class="{true: 'glyphicon-minus-sign', false: 'glyphicon-plus-sign'}[!devSettingsArgs.toggle]" class="glyphicon glyphicon-minus-sign"></span>
             </div>
             <div class="dev-section" ng-show="!devSettingsArgs.toggle">
-              <textarea id="inputSolrArgsStr" ng-model="searchSettings.searchArgsStr" rows="10" class="form-control ng-pristine ng-valid"></textarea> 
+              <textarea id="inputSolrArgsStr" ng-model="searchSettings.searchArgsStrShow" rows="10" class="form-control ng-pristine ng-valid"></textarea> 
             </div>
             <div class="dev-section">
               <button type="submit" class="btn btn-default">Rerun Query</button>

--- a/app/scripts/controllers/docSelector.js
+++ b/app/scripts/controllers/docSelector.js
@@ -4,7 +4,7 @@ angular.module('splain-app')
   .controller('DocSelectorCtrl', function DocExplainCtrl($scope, searchSvc, solrUrlSvc, settingsStoreSvc) {
     // this controller is a bit silly just because
     // modals need their own controller
-    
+
     var addToSolrArgs = function(solrArgsStr, newParams) {
       var solrArgs = solrUrlSvc.parseSolrArgs(solrArgsStr);
       angular.forEach(newParams, function(value, arg) {
@@ -19,11 +19,11 @@ angular.module('splain-app')
     $scope.explainOther = function(altQuery) {
       var searchSettings = settingsStoreSvc.settings;
 
-      // explainOther by passing a explainOther=<luceneQuery> to 
+      // explainOther by passing a explainOther=<luceneQuery> to
       // the user's current settings and rerunning the search
       searchSettings = angular.copy(searchSettings);
       // we should be using the solrUrlSvc to do this
-      searchSettings.searchArgsStr = addToSolrArgs(searchSettings.searchArgsStr, 
+      searchSettings.searchArgsStr = addToSolrArgs(searchSettings.searchArgsStr,
                                                    {'explainOther': [altQuery]});
       var explainOtherSearch = searchSvc.createSearch(searchSettings);
       explainOtherSearch.search()

--- a/app/scripts/services/settingsStoreSvc.js
+++ b/app/scripts/services/settingsStoreSvc.js
@@ -7,9 +7,9 @@ angular.module('splain-app')
     this.ENGINES.SOLR = 0;
     this.ENGINES.ELASTICSEARCH = 1;
 
-    // Next is Local Storage 
+    // Next is Local Storage
     var initSearchArgs = function() {
-      var searchSettings = {searchUrl: '', fieldSpecStr: '', searchArgsStr: ''};
+      var searchSettings = {searchUrl: '', fieldSpecStr: '', searchArgsStr: '', searchArgsStrShow: ''};
       var localStorageTryGet = function(key) {
         var val;
         try {
@@ -17,7 +17,7 @@ angular.module('splain-app')
         } catch (SyntaxError) {
           val = null;
         }
-          
+
         if (val !== null) {
           searchSettings[key] = val;
         } else {
@@ -29,6 +29,7 @@ angular.module('splain-app')
         localStorageTryGet('startUrl');
         localStorageTryGet('fieldSpecStr');
         localStorageTryGet('searchArgsStr');
+        localStorageTryGet('searchArgsStrShow');
         localStorageTryGet('whichEngine');
       }
       searchSettings.searchArgsStr = searchSettings.searchArgsStr.slice(1);
@@ -41,6 +42,7 @@ angular.module('splain-app')
         localStorageService.set('searchUrl', searchSettings.searchUrl);
         localStorageService.set('fieldSpecStr', searchSettings.fieldSpecStr);
         localStorageService.set('searchArgsStr', '!' + searchSettings.searchArgsStr);
+        localStorageService.set('searchArgsStrShow', searchSettings.searchArgsStr.split('&').join('\n'));
         localStorageService.set('whichEngine', searchSettings.whichEngine);
       }
       $location.search({'solr':  searchSettings.startUrl});

--- a/app/scripts/services/solrSettingsSvc.js
+++ b/app/scripts/services/solrSettingsSvc.js
@@ -21,7 +21,7 @@ angular.module('splain-app')
     };
 
     var newlineSolrArgs = function(searchArgsStr) {
-      return searchArgsStr.split('&').join('\n&');
+      return searchArgsStr;//.split('&').join('\n&'); // remove &
     };
 
     var fromParsedUrl = function(userSettings, parsedUrl) {
@@ -39,23 +39,28 @@ angular.module('splain-app')
       }
       userSettings.searchUrl = parsedUrl.solrEndpoint();
     };
-    
+
     /* Update/sanitize settings from user input when tweaking
      * (ie user updates solr URL or search args, fields, etc)
-     * */ 
+     * */
     this.fromTweakedSettings = function(searchSettings) {
+      if (searchSettings.searchArgsStrShow) {
+        searchSettings.searchArgsStr = searchSettings.searchArgsStrShow.split('\n').join('&');
+      }
+
       var parsedUrl = solrUrlSvc.parseSolrUrl(searchSettings.searchUrl);
       if (parsedUrl !== null && parsedUrl.solrArgs && Object.keys(parsedUrl.solrArgs).length > 0) {
         fromParsedUrl(searchSettings, parsedUrl);
       }
       searchSettings.startUrl = reconstructFullUrl(searchSettings);
+
       return searchSettings;
     };
 
     /* Create settings from a pasted in user URL
      * (ie from start screen)
      *
-     * */ 
+     * */
     this.fromStartUrl = function(newStartUrl, searchSettings) {
       searchSettings.whichEngine = 0;
       searchSettings.startUrl = newStartUrl;
@@ -63,6 +68,9 @@ angular.module('splain-app')
       if (parsedUrl !== null) {
         fromParsedUrl(searchSettings, parsedUrl);
       }
+
+      searchSettings.searchArgsStrShow = searchSettings.searchArgsStr.split('&').join('\n');
+
       return searchSettings;
     };
 

--- a/app/views/docSelect.html
+++ b/app/views/docSelect.html
@@ -12,19 +12,9 @@
     </form>
   </div>
   </hr>
-  <div class="container" ng-if="!currSearch.hasGrouped()" ng-repeat="doc in currSearch.docs">
+  <div class="container" ng-repeat="doc in currSearch.docs">
     <doc-row detailed-explain-link="false" max-score="currSearch.maxScore" doc="doc" ng-click="selectDoc(doc)"></doc-row>
     <hr/>
-  </div>
-  <div class="grouped " ng-if="currSearch.hasGrouped()" ng-repeat="(group, groupedBy) in currSearch.grouped">
-    <h4>Grouped by: {{group}}</h4>
-    <div class="container" ng-repeat="grouped in groupedBy">
-     <h4 style="margin-left: 10px" title = "Group: {{group}}, {{grouped.value}}">Value: <em>{{grouped.value}}</em></h4>
-     <div ng-repeat="doc in grouped.docs">
-       <doc-row detailed-explain-link="false" max-score="currSearch.maxScore" doc="doc" ng-click="selectDoc(doc)"></doc-row>
-      </div>
-      <hr/>
-    </div>
   </div>
   <!--div>
     <div ng-show="!currSearch.paging && currSearch.moreResults()" id="pager" class="col-sm-3 col-sm-offset-5"><a href="" ng-click="currSearch.page()">Select From More Results</a></div>

--- a/app/views/docSelect.html
+++ b/app/views/docSelect.html
@@ -3,7 +3,7 @@
     <form ng-submit="explainOther(altQuery)">
       <div class="col-md-1"></div>
       <div class="col-md-7">
-        <input class="form-control" id="altQuery" ng-model="altQuery" placeholder="Search For Other Docs To Explain (use Solr Query syntax)" type="text"></input>
+        <input class="form-control" id="altQuery" ng-model="altQuery" placeholder="Search For Other Docs To Compare (use Solr Query syntax)" type="text"></input>
       </div>
       <div class="col-md-3">
         <input class="btn btn-primary form-control" type="submit" value="Find Others"></input>
@@ -19,9 +19,11 @@
   <div class="grouped " ng-if="currSearch.hasGrouped()" ng-repeat="(group, groupedBy) in currSearch.grouped">
     <h4>Grouped by: {{group}}</h4>
     <div class="container" ng-repeat="grouped in groupedBy">
-      <doc-row detailed-explain-link="false" max-score="currSearch.maxScore" doc="doc" ng-click="selectDoc(doc)"></doc-row>
+     <h4 style="margin-left: 10px" title = "Group: {{group}}, {{grouped.value}}">Value: <em>{{grouped.value}}</em></h4>
+     <div ng-repeat="doc in grouped.docs">
+       <doc-row detailed-explain-link="false" max-score="currSearch.maxScore" doc="doc" ng-click="selectDoc(doc)"></doc-row>
+      </div>
       <hr/>
-
     </div>
   </div>
   <!--div>

--- a/test/spec/controllers/solrSettings.js
+++ b/test/spec/controllers/solrSettings.js
@@ -11,12 +11,12 @@ describe('solrSettingsCtrl', function() {
   beforeEach(function() {
     /* global MockLocalStorageService*/
     localStorage = new MockLocalStorageService();
-    
+
     module(function($provide) {
       $provide.value('localStorageService', localStorage);
     });
-    
-    
+
+
     inject(function($rootScope, $controller) {
 
       createController = function() {
@@ -55,7 +55,7 @@ describe('solrSettingsCtrl', function() {
       expect(scope.searchSettings.fieldSpecStr).toEqual('');
       expect(scope.searchSettings.searchArgsStr).toEqual('');
     });
-    
+
     it('loads all', function() {
       localStorage.isSupported = true;
       var testUrl = 'http://localhost:8983/solr/collection1/select';
@@ -77,7 +77,7 @@ describe('solrSettingsCtrl', function() {
   });
 
   describe('save settings', function() {
-    
+
     describe('multiple setting input', function() {
       var testUrl = 'http://localhost:8983/solr/collection1/select';
       var testFieldSpec = 'field1';
@@ -88,7 +88,7 @@ describe('solrSettingsCtrl', function() {
         scope.searchSettings.searchUrl = testUrl;
         scope.searchSettings.searchArgsStr = testArgsStr;
         scope.searchSettings.fieldSpecStr = testFieldSpec;
-        spyOn(scope.search, 'search').andCallThrough();        
+        spyOn(scope.search, 'search').andCallThrough();
         scope.searchSettings.publishSearcher();
       });
 
@@ -101,7 +101,7 @@ describe('solrSettingsCtrl', function() {
         expect(localStorage.get('fieldSpecStr')).toEqual(testFieldSpec);
         expect(localStorage.get('searchArgsStr').slice(1)).toEqual(testArgsStr);
       });
-      
+
     });
 
     // someone just pastes in a big URL
@@ -109,7 +109,7 @@ describe('solrSettingsCtrl', function() {
       var testUserUrl = 'http://localhost:8983/solr/collection1/select?q=*:*&fl=field1';
       var testUrlEncodedUrl = 'http://localhost:8983/solr/collection1/select?q=choice%20of%20law&defType=edismax&qf=catch_line%20text&pf=catch_line&fl=catch_line%20text';
       var testUserUrlBase = 'http://localhost:8983/solr/collection1/select';
-      
+
       beforeEach(function() {
       });
 
@@ -129,18 +129,18 @@ describe('solrSettingsCtrl', function() {
         scope.searchSettings.publishSearcher();
 
         expect(scope.searchSettings.fieldSpecStr).toEqual('catch_line text');
-        expect(scope.searchSettings.searchArgsStr).toEqual('q=choice of law\n&defType=edismax\n&qf=catch_line text\n&pf=catch_line');
+        expect(scope.searchSettings.searchArgsStr).toEqual('q=choice of law&defType=edismax&qf=catch_line text&pf=catch_line');
         expect(scope.searchSettings.searchUrl).toEqual(testUserUrlBase);
 
       });
-      
+
     });
-    
+
     describe('url and preexisting input', function() {
       var testNewUserUrl = 'http://localhost:8983/solr/collection1/select?q=field:foo&fl=field1';
       var testFieldSpecStr = 'field1';
       var testArgsStr = 'q=*:*';
-      
+
       beforeEach(function() {
         localStorage.store.searchArgsStr = testArgsStr;
         localStorage.store.fieldSpecStr = testFieldSpecStr;
@@ -151,11 +151,11 @@ describe('solrSettingsCtrl', function() {
         scope.searchSettings.searchUrl = testNewUserUrl;
         scope.searchSettings.publishSearcher();
       });
-      
+
     });
 
 
   });
-  
+
 
 });

--- a/test/spec/services/solrSettingsSvc.js
+++ b/test/spec/services/solrSettingsSvc.js
@@ -4,21 +4,21 @@ describe('Service: solrSettingsSvc', function () {
 
   // load the service's module
   beforeEach(module('splain-app'));
-  
+
   var solrSettingsSvc = null;
   var solrUrlSvc = null;
   beforeEach(inject(function (_solrSettingsSvc_, _solrUrlSvc_) {
     solrSettingsSvc = _solrSettingsSvc_;
     solrUrlSvc = _solrUrlSvc_;
   }));
-  
+
   var stubSettings = function() {
     return {
       startUrl: '',
       whichEngine: '',
       searchUrl: '',
       fieldSpecStr: '',
-      searchArgsStr: ''  
+      searchArgsStr: ''
     };
   };
 
@@ -26,52 +26,52 @@ describe('Service: solrSettingsSvc', function () {
     var settings = stubSettings();
     var startUrl = 'http://localhost:8983/solr/example?q=*:*&fl=title catch_line';
     solrSettingsSvc.fromStartUrl(startUrl, settings);
-    expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');    
+    expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');
     expect(settings.fieldSpecStr).toEqual('title catch_line');
     expect(settings.searchArgsStr).toEqual('q=*:*');
     expect(settings.whichEngine).toEqual(0);
     expect(settings.startUrl).toEqual('http://localhost:8983/solr/example?q=*:*&fl=title catch_line');
   });
-  
+
   it('uses default (*) fieldspec when no fl specified', function() {
     var settings = stubSettings();
     var startUrl = 'http://localhost:8983/solr/example?q=*:*';
     solrSettingsSvc.fromStartUrl(startUrl, settings);
-    expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');    
+    expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');
     expect(settings.fieldSpecStr).toEqual('*');
     expect(settings.searchArgsStr).toEqual('q=*:*');
     expect(settings.whichEngine).toEqual(0);
     expect(settings.startUrl).toEqual('http://localhost:8983/solr/example?q=*:*');
   });
-  
+
   it('uses start URL even with no args', function() {
     var settings = stubSettings();
     var startUrl = 'http://localhost:8983/solr/example';
     solrSettingsSvc.fromStartUrl(startUrl, settings);
-    expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');    
+    expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');
     expect(settings.fieldSpecStr).toEqual('*');
     expect(settings.searchArgsStr).toEqual('q=*:*');
     expect(settings.whichEngine).toEqual(0);
     expect(settings.startUrl).toEqual('http://localhost:8983/solr/example');
   });
-  
+
   it('updates start URL from args updates', function() {
     var settings = stubSettings();
     var startUrl = 'http://localhost:8983/solr/example?q=*:*&fl=title catch_line';
     solrSettingsSvc.fromStartUrl(startUrl, settings);
 
-    settings.searchArgsStr = 'q=*:*\n&fq=blah';
+    settings.searchArgsStrShow = 'q=*:*\nfq=blah';
     solrSettingsSvc.fromTweakedSettings(settings);
 
     expect(settings.startUrl.indexOf('blah')).not.toEqual(-1);
   });
-  
+
   it('updates start URL from args updates, empty fl', function() {
     var settings = stubSettings();
     var startUrl = 'http://localhost:8983/solr/example?q=*:*';
     solrSettingsSvc.fromStartUrl(startUrl, settings);
 
-    settings.searchArgsStr = 'q=*:*\n&fq=blah';
+    settings.searchArgsStrShow = 'q=*:*\nfq=blah';
     solrSettingsSvc.fromTweakedSettings(settings);
 
     expect(settings.startUrl.indexOf('blah')).not.toEqual(-1);
@@ -83,9 +83,9 @@ describe('Service: solrSettingsSvc', function () {
     var settings = stubSettings();
     var startUrl = 'http://localhost:8983/solr/example?q=*:*&fq=cat:meow&fl=title catch_line';
     solrSettingsSvc.fromStartUrl(startUrl, settings);
-    expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');    
+    expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');
     expect(settings.fieldSpecStr).toEqual('title catch_line');
-    expect(settings.searchArgsStr).toEqual('q=*:*\n&fq=cat:meow');
+    expect(settings.searchArgsStr).toEqual('q=*:*&fq=cat:meow');
     expect(settings.whichEngine).toEqual(0);
     expect(settings.startUrl).toEqual('http://localhost:8983/solr/example?q=*:*&fq=cat:meow&fl=title catch_line');
   });


### PR DESCRIPTION
Previously if you used explain other with a base group by, you'd get some attempt to show the other results as group-by. The markup involved was broken, and didn't actually display grouped results correctly.

![group_by_explain_other_bug](https://cloud.githubusercontent.com/assets/629060/8782654/f2be8290-2ee4-11e5-9aa0-455c42a28b9c.gif)

This simplifies this display by not caring if the results are grouped or not for explain other. Instead we show flat, simpler search results for the explainOther query

![group_by_explain_other_fix](https://cloud.githubusercontent.com/assets/629060/8782696/2d460014-2ee5-11e5-86c1-0b1561eae086.gif)

