### PR TITLE
Fix explain other view when group by results come back from Solr

### DIFF
--- a/app/views/docSelect.html
+++ b/app/views/docSelect.html
@@ -12,19 +12,9 @@
     </form>
   </div>
   </hr>
-  <div class="container" ng-if="!currSearch.hasGrouped()" ng-repeat="doc in currSearch.docs">
+  <div class="container" ng-repeat="doc in currSearch.docs">
     <doc-row detailed-explain-link="false" max-score="currSearch.maxScore" doc="doc" ng-click="selectDoc(doc)"></doc-row>
     <hr/>
-  </div>
-  <div class="grouped " ng-if="currSearch.hasGrouped()" ng-repeat="(group, groupedBy) in currSearch.grouped">
-    <h4>Grouped by: {{group}}</h4>
-    <div class="container" ng-repeat="grouped in groupedBy">
-     <h4 style="margin-left: 10px" title = "Group: {{group}}, {{grouped.value}}">Value: <em>{{grouped.value}}</em></h4>
-     <div ng-repeat="doc in grouped.docs">
-       <doc-row detailed-explain-link="false" max-score="currSearch.maxScore" doc="doc" ng-click="selectDoc(doc)"></doc-row>
-      </div>
-      <hr/>
-    </div>
   </div>
   <!--div>
     <div ng-show="!currSearch.paging && currSearch.moreResults()" id="pager" class="col-sm-3 col-sm-offset-5"><a href="" ng-click="currSearch.page()">Select From More Results</a></div>

--- a/app/views/docSelect.html
+++ b/app/views/docSelect.html
@@ -3,7 +3,7 @@
     <form ng-submit="explainOther(altQuery)">
       <div class="col-md-1"></div>
       <div class="col-md-7">
-        <input class="form-control" id="altQuery" ng-model="altQuery" placeholder="Search For Other Docs To Explain (use Solr Query syntax)" type="text"></input>
+        <input class="form-control" id="altQuery" ng-model="altQuery" placeholder="Search For Other Docs To Compare (use Solr Query syntax)" type="text"></input>
       </div>
       <div class="col-md-3">
         <input class="btn btn-primary form-control" type="submit" value="Find Others"></input>
@@ -19,9 +19,11 @@
   <div class="grouped " ng-if="currSearch.hasGrouped()" ng-repeat="(group, groupedBy) in currSearch.grouped">
     <h4>Grouped by: {{group}}</h4>
     <div class="container" ng-repeat="grouped in groupedBy">
-      <doc-row detailed-explain-link="false" max-score="currSearch.maxScore" doc="doc" ng-click="selectDoc(doc)"></doc-row>
+     <h4 style="margin-left: 10px" title = "Group: {{group}}, {{grouped.value}}">Value: <em>{{grouped.value}}</em></h4>
+     <div ng-repeat="doc in grouped.docs">
+       <doc-row detailed-explain-link="false" max-score="currSearch.maxScore" doc="doc" ng-click="selectDoc(doc)"></doc-row>
+      </div>
       <hr/>
-
     </div>
   </div>
   <!--div>


### PR DESCRIPTION
With explain other, users enter a query for a secondary search and expect to see explanations of a set of results against the main query. To support this functionality,  splainer makes 2 calls to Solr to get explain other results. Once to pull back the explanations against the main query and a second one to pull back the fields for those secondary results. This second result set becomes the basis for displaying explain other results (with explains monkey patched on top)

If this second set of results involves a group by (perhaps because its hard coded in the request handler), weird things happen:
![group_by_explain_other_bug](https://cloud.githubusercontent.com/assets/629060/8782654/f2be8290-2ee4-11e5-9aa0-455c42a28b9c.gif)

This PR simplifies this display by not caring if the results are grouped or not for explain other. Instead we show flat, simpler search results for the explainOther query. This is done by using the flattened "docs" that is always populated regardless of grouping.

![group_by_explain_other_fix](https://cloud.githubusercontent.com/assets/629060/8782696/2d460014-2ee5-11e5-86c1-0b1561eae086.gif)
