### PR TITLE
Upgrade splainer search

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -8,7 +8,7 @@
   "eqeqeq": true,
   "immed": true,
   "indent": 2,
-  "latedef": true,
+  "latedef": "nofunc",
   "newcap": true,
   "noarg": true,
   "quotmark": "single",

--- a/app/index.html
+++ b/app/index.html
@@ -120,6 +120,7 @@
     <script src="bower_components/angular-local-storage/angular-local-storage.js"></script>
     <script src="bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
     <script src="bower_components/ng-json-explorer/src/gd-ui-jsonexplorer.js"></script>
+    <script src="bower_components/urijs/src/URI.js"></script>
     <script src="bower_components/splainer-search/splainer-search.js"></script>
     <script src="bower_components/inspector-gadget/inspector-gadget.js"></script>
     <!-- endbower -->
@@ -137,7 +138,7 @@
       <script src="scripts/directives/docSelector.js"></script>
       <script src="scripts/directives/stackedChart.js"></script>
       <script src="scripts/services/solrSettingsSvc.js"></script>
-      <script src="scripts/services/searchSvc.js"></script>
+      <script src="scripts/services/splSearchSvc.js"></script>
       <script src="scripts/services/settingsStoreSvc.js"></script>
       <script src="scripts/controllers/docRow.js"></script>
       <script src="scripts/controllers/detailedExplain.js"></script>

--- a/app/scripts/controllers/docSelector.js
+++ b/app/scripts/controllers/docSelector.js
@@ -1,10 +1,10 @@
 'use strict';
 
 angular.module('splain-app')
-  .controller('DocSelectorCtrl', function DocExplainCtrl($scope, searchSvc, solrUrlSvc, settingsStoreSvc) {
+  .controller('DocSelectorCtrl', function DocExplainCtrl($scope, spl_searchSvc, solrUrlSvc, settingsStoreSvc) {
     // this controller is a bit silly just because
     // modals need their own controller
-    
+
     var addToSolrArgs = function(solrArgsStr, newParams) {
       var solrArgs = solrUrlSvc.parseSolrArgs(solrArgsStr);
       angular.forEach(newParams, function(value, arg) {
@@ -19,20 +19,20 @@ angular.module('splain-app')
     $scope.explainOther = function(altQuery) {
       var searchSettings = settingsStoreSvc.settings;
 
-      // explainOther by passing a explainOther=<luceneQuery> to 
+      // explainOther by passing a explainOther=<luceneQuery> to
       // the user's current settings and rerunning the search
       searchSettings = angular.copy(searchSettings);
       // we should be using the solrUrlSvc to do this
-      searchSettings.searchArgsStr = addToSolrArgs(searchSettings.searchArgsStr, 
+      searchSettings.searchArgsStr = addToSolrArgs(searchSettings.searchArgsStr,
                                                    {'explainOther': [altQuery]});
-      var explainOtherSearch = searchSvc.createSearch(searchSettings);
+      var explainOtherSearch = spl_searchSvc.createSearch(searchSettings);
       explainOtherSearch.search()
       .then(function() {
         // but we don't get anything but an explain, so let's re-search
         // and try to pull back the right data
         searchSettings = angular.copy(searchSettings);
         searchSettings.searchArgsStr = 'q=' + altQuery;
-        $scope.currSearch = searchSvc.createSearch(searchSettings, explainOtherSearch.searcher.othersExplained);
+        $scope.currSearch = spl_searchSvc.createSearch(searchSettings, explainOtherSearch.searcher.othersExplained);
         $scope.currSearch.search();
       });
     };

--- a/app/scripts/controllers/docSelector.js
+++ b/app/scripts/controllers/docSelector.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('splain-app')
-  .controller('DocSelectorCtrl', function DocExplainCtrl($scope, spl_searchSvc, solrUrlSvc, settingsStoreSvc) {
+  .controller('DocSelectorCtrl', function DocExplainCtrl($scope, splSearchSvc, solrUrlSvc, settingsStoreSvc) {
     // this controller is a bit silly just because
     // modals need their own controller
 
@@ -25,14 +25,14 @@ angular.module('splain-app')
       // we should be using the solrUrlSvc to do this
       searchSettings.searchArgsStr = addToSolrArgs(searchSettings.searchArgsStr,
                                                    {'explainOther': [altQuery]});
-      var explainOtherSearch = spl_searchSvc.createSearch(searchSettings);
+      var explainOtherSearch = splSearchSvc.createSearch(searchSettings);
       explainOtherSearch.search()
       .then(function() {
         // but we don't get anything but an explain, so let's re-search
         // and try to pull back the right data
         searchSettings = angular.copy(searchSettings);
         searchSettings.searchArgsStr = 'q=' + altQuery;
-        $scope.currSearch = spl_searchSvc.createSearch(searchSettings, explainOtherSearch.searcher.othersExplained);
+        $scope.currSearch = splSearchSvc.createSearch(searchSettings, explainOtherSearch.searcher.othersExplained);
         $scope.currSearch.search();
       });
     };

--- a/app/scripts/controllers/searchResults.js
+++ b/app/scripts/controllers/searchResults.js
@@ -8,13 +8,13 @@
  * Controller of the frontendApp
  */
 angular.module('splain-app')
-  .controller('SearchResultsCtrl', function ($scope, searchSvc, settingsStoreSvc) {
-  
+  .controller('SearchResultsCtrl', function ($scope, spl_searchSvc, settingsStoreSvc) {
+
 
     $scope.search = {};
 
     /* Initiate a new search with the latest settings
-     * */ 
+     * */
     $scope.search.search = function() {
       var promise = Promise.create($scope.search.search);
       $scope.search.reset();
@@ -27,9 +27,9 @@ angular.module('splain-app')
 
     $scope.search.reset = function() {
       var searchSettings = settingsStoreSvc.settings;
-      $scope.currSearch = searchSvc.createSearch(searchSettings);
+      $scope.currSearch = spl_searchSvc.createSearch(searchSettings);
     };
-    
+
     $scope.search.reset();
 
   });

--- a/app/scripts/controllers/searchResults.js
+++ b/app/scripts/controllers/searchResults.js
@@ -8,7 +8,7 @@
  * Controller of the frontendApp
  */
 angular.module('splain-app')
-  .controller('SearchResultsCtrl', function ($scope, spl_searchSvc, settingsStoreSvc) {
+  .controller('SearchResultsCtrl', function ($scope, splSearchSvc, settingsStoreSvc) {
 
 
     $scope.search = {};
@@ -27,7 +27,7 @@ angular.module('splain-app')
 
     $scope.search.reset = function() {
       var searchSettings = settingsStoreSvc.settings;
-      $scope.currSearch = spl_searchSvc.createSearch(searchSettings);
+      $scope.currSearch = splSearchSvc.createSearch(searchSettings);
     };
 
     $scope.search.reset();

--- a/app/scripts/services/splSearchSvc.js
+++ b/app/scripts/services/splSearchSvc.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('splain-app')
-  .service('spl_searchSvc', function solrSettingsSvc(solrUrlSvc, fieldSpecSvc, searchSvc, normalDocsSvc) {
+  .service('splSearchSvc', function splSearchSvc(solrUrlSvc, fieldSpecSvc, searchSvc, normalDocsSvc) {
 
     this.states = {
       NO_SEARCH: 0,
@@ -110,13 +110,9 @@ angular.module('splain-app')
 
         var thisSearch = this;
         this.searcher.search()
-        .then(function() {
+        .then(function success() {
           thisSearch.linkUrl = thisSearch.searcher.linkUrl;
           thisSearch.numFound = thisSearch.searcher.numFound;
-          if (thisSearch.searcher.inError) {
-            thisSearch.state = thisSvc.states.IN_ERROR;
-            return;
-          }
           angular.forEach(thisSearch.searcher.docs, function(doc) {
             var overridingExpl = thisSearch.getOverridingExplain(doc, fieldSpec);
             var normalDoc = normalDocsSvc.createNormalDoc(fieldSpec, doc, overridingExpl);
@@ -132,6 +128,9 @@ angular.module('splain-app')
           groupedResultToNormalDocs(fieldSpec, thisSearch.grouped);
           thisSearch.state = thisSvc.states.DID_SEARCH;
           promise.complete();
+        }, function searchFailure() {
+          thisSearch.state = thisSvc.states.IN_ERROR;
+          return;
         });
 
         return promise;

--- a/app/scripts/services/splSearchSvc.js
+++ b/app/scripts/services/splSearchSvc.js
@@ -1,18 +1,18 @@
 'use strict';
 
 angular.module('splain-app')
-  .service('searchSvc', function solrSettingsSvc(solrUrlSvc, fieldSpecSvc, solrSearchSvc, esSearchSvc, normalDocsSvc) {
+  .service('spl_searchSvc', function solrSettingsSvc(solrUrlSvc, fieldSpecSvc, searchSvc, normalDocsSvc) {
 
     this.states = {
       NO_SEARCH: 0,
       DID_SEARCH: 1,
       WAITING_FOR_SEARCH: 2,
-      IN_ERROR: 3      
+      IN_ERROR: 3
     };
 
     this.engines = {
-      SOLR: 0,
-      ELASTICSEARCH: 1
+      SOLR: 'solr',
+      ELASTICSEARCH: 'elasticsearch'
     };
 
     var thisSvc = this;
@@ -20,19 +20,22 @@ angular.module('splain-app')
     var createSearcher = function(fieldSpec, parsedArgs, searchSettings) {
       if (searchSettings.whichEngine === thisSvc.engines.ELASTICSEARCH) {
         try {
-          parsedArgs = angular.fromJson(searchSettings.searchArgsStr); 
+          parsedArgs = angular.fromJson(searchSettings.searchArgsStr);
         } catch (SyntaxError) {
           parsedArgs = '';
         }
-          
-        return esSearchSvc.createSearcher(fieldSpec.fieldList(),
-                                          searchSettings.searchUrl, parsedArgs, '');
-        
       } else {
         parsedArgs = solrUrlSvc.parseSolrArgs(searchSettings.searchArgsStr);
-        return solrSearchSvc.createSearcher(fieldSpec.fieldList(),
-                                            searchSettings.searchUrl, parsedArgs, '');
       }
+
+      return searchSvc.createSearcher(fieldSpec.fieldList(),
+                                      searchSettings.searchUrl,
+                                      parsedArgs,
+                                      '',
+                                      {},
+                                      searchSettings.whichEngine);
+
+
     };
 
     var groupedResultToNormalDocs = function(fieldSpec, groupedByResp) {
@@ -51,6 +54,9 @@ angular.module('splain-app')
       search.DID_SEARCH = this.states.DID_SEARCH;
       search.WAITING_FOR_SEARCH = this.states.WAITING_FOR_SEARCH;
       search.IN_ERROR = this.states.IN_ERROR;
+      if (!searchSettings.whichEngine) {
+        searchSettings.whichEngine = this.engines.SOLR;
+      }
       return search;
     };
 

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "angular-local-storage": "~0.0.5",
     "angular-bootstrap": "~0.11.0",
     "ng-json-explorer": "git://github.com/softwaredoug/ng-json-explorer",
-    "splainer-search": "git://github.com/o19s/splainer-search.git#0.1.9",
+    "splainer-search": "1.3.2",
     "angular-sanitize": "~1.2.21",
     "jquery": "~2.1.1",
     "inspector-gadget": "^0.2.0"

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "splainer",
   "version": "0.0.0",
   "dependencies": {
-    "angular": "~1.2.26",
+    "angular": "~1.4.0",
     "json3": "~3.3.1",
     "es5-shim": "~3.1.0",
     "bootstrap": "~3.2.0",
@@ -10,13 +10,13 @@
     "angular-bootstrap": "~0.11.0",
     "ng-json-explorer": "git://github.com/softwaredoug/ng-json-explorer",
     "splainer-search": "1.3.2",
-    "angular-sanitize": "~1.2.21",
+    "angular-sanitize": "~1.4.0",
     "jquery": "~2.1.1",
     "inspector-gadget": "^0.2.0"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.26",
-    "angular-scenario": "~1.2.26"
+    "angular-mocks": "~1.4.0",
+    "angular-scenario": "~1.4.0"
   },
   "appPath": "app",
   "resolutions": {

--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
   "appPath": "app",
   "resolutions": {
     "json3": "~3.3.1",
-    "es5-shim": "~3.1.0"
+    "es5-shim": "~3.1.0",
+    "angular": "~1.4.0"
   }
 }


### PR DESCRIPTION
Upgrades splainer-search library to latest version. This is part of an effort to get splainer to use Elasticsearch. I made minimal changes focused purely on the upgrade and functionality.

## Acceptance Criteria
- Splainer should act exactly as it does today with no new bugs introduced