### PR TITLE
Link to broken Solr URL was missing

### DIFF
--- a/app/scripts/services/splSearchSvc.js
+++ b/app/scripts/services/splSearchSvc.js
@@ -130,6 +130,7 @@ angular.module('splain-app')
           promise.complete();
         }, function searchFailure() {
           thisSearch.state = thisSvc.states.IN_ERROR;
+          thisSearch.linkUrl = thisSearch.searcher.linkUrl;
           return;
         });
 


### PR DESCRIPTION
When a Solr error occured, the linkUrl from splainer-search wasn't passed to splainer's query object. The result is when Splainer prompts you for an error, the link doesn't work.