### PR TITLE
Adds fieldSpec to splainerized URL

### DIFF
--- a/app/scripts/controllers/startUrl.js
+++ b/app/scripts/controllers/startUrl.js
@@ -6,8 +6,8 @@ angular.module('splain-app')
     $scope.start = {};
     $scope.start.settings = settingsStoreSvc.settings;
 
-    var onStartUrl = function() {
-      solrSettingsSvc.fromStartUrl($scope.start.settings.startUrl, $scope.start.settings);
+    var onStartUrl = function(overridingFieldSpec) {
+      solrSettingsSvc.fromStartUrl($scope.start.settings.startUrl, $scope.start.settings, overridingFieldSpec);
       $scope.search.search()
       .then(function() {
         settingsStoreSvc.save();
@@ -16,7 +16,11 @@ angular.module('splain-app')
 
     if ($location.search().hasOwnProperty('solr')) {
       $scope.start.settings.startUrl = $location.search().solr;
-      onStartUrl();
+      var overridingFieldSpec;
+      if ($location.search().hasOwnProperty('fieldSpec')) {
+        overridingFieldSpec = $location.search().fieldSpec;
+      }
+      onStartUrl(overridingFieldSpec);
     }
 
     $scope.start.submit = function() {

--- a/app/scripts/services/settingsStoreSvc.js
+++ b/app/scripts/services/settingsStoreSvc.js
@@ -7,7 +7,7 @@ angular.module('splain-app')
     this.ENGINES.SOLR = 0;
     this.ENGINES.ELASTICSEARCH = 1;
 
-    // Next is Local Storage 
+    // Next is Local Storage
     var initSearchArgs = function() {
       var searchSettings = {searchUrl: '', fieldSpecStr: '', searchArgsStr: ''};
       var localStorageTryGet = function(key) {
@@ -17,7 +17,7 @@ angular.module('splain-app')
         } catch (SyntaxError) {
           val = null;
         }
-          
+
         if (val !== null) {
           searchSettings[key] = val;
         } else {
@@ -43,7 +43,7 @@ angular.module('splain-app')
         localStorageService.set('searchArgsStr', '!' + searchSettings.searchArgsStr);
         localStorageService.set('whichEngine', searchSettings.whichEngine);
       }
-      $location.search({'solr':  searchSettings.startUrl});
+      $location.search({'solr':  searchSettings.startUrl, 'fieldSpec': searchSettings.fieldSpecStr});
     };
 
     // init from local storage if there

--- a/app/scripts/services/solrSettingsSvc.js
+++ b/app/scripts/services/solrSettingsSvc.js
@@ -24,14 +24,16 @@ angular.module('splain-app')
       return searchArgsStr.split('&').join('\n&');
     };
 
-    var fromParsedUrl = function(userSettings, parsedUrl) {
+    var fromParsedUrl = function(userSettings, parsedUrl, overrideFieldSpec) {
       var argsToUse = angular.copy(parsedUrl.solrArgs);
       solrUrlSvc.removeUnsupported(argsToUse);
       userSettings.searchArgsStr = newlineSolrArgs(solrUrlSvc.formatSolrArgs(argsToUse));
       if (userSettings.searchArgsStr.trim().length === 0) {
         userSettings.searchArgsStr = 'q=*:*';
       }
-      if (parsedUrl.solrArgs.hasOwnProperty('fl')) {
+      if (overrideFieldSpec) {
+        userSettings.fieldSpecStr = overrideFieldSpec;
+      } else if (parsedUrl.solrArgs.hasOwnProperty('fl')) {
         var fl = parsedUrl.solrArgs.fl;
         userSettings.fieldSpecStr = fl[0];
       } else {
@@ -39,10 +41,10 @@ angular.module('splain-app')
       }
       userSettings.searchUrl = parsedUrl.solrEndpoint();
     };
-    
+
     /* Update/sanitize settings from user input when tweaking
      * (ie user updates solr URL or search args, fields, etc)
-     * */ 
+     * */
     this.fromTweakedSettings = function(searchSettings) {
       var parsedUrl = solrUrlSvc.parseSolrUrl(searchSettings.searchUrl);
       if (parsedUrl !== null && parsedUrl.solrArgs && Object.keys(parsedUrl.solrArgs).length > 0) {
@@ -55,13 +57,13 @@ angular.module('splain-app')
     /* Create settings from a pasted in user URL
      * (ie from start screen)
      *
-     * */ 
-    this.fromStartUrl = function(newStartUrl, searchSettings) {
+     * */
+    this.fromStartUrl = function(newStartUrl, searchSettings, overrideFieldSpec) {
       searchSettings.whichEngine = 0;
       searchSettings.startUrl = newStartUrl;
       var parsedUrl = solrUrlSvc.parseSolrUrl(newStartUrl);
       if (parsedUrl !== null) {
-        fromParsedUrl(searchSettings, parsedUrl);
+        fromParsedUrl(searchSettings, parsedUrl, overrideFieldSpec);
       }
       return searchSettings;
     };

--- a/test/spec/controllers/startUrl.js
+++ b/test/spec/controllers/startUrl.js
@@ -8,7 +8,7 @@ describe('searchResultsCtrl', function() {
   var localStorageSvc = null;
 
   beforeEach(module('splain-app'));
-  
+
   beforeEach(function() {
     /* global MockLocationSvc*/
     /* global MockLocalStorageService*/
@@ -35,7 +35,7 @@ describe('searchResultsCtrl', function() {
       };
     });
   });
-  
+
   beforeEach(function() {
     localStorageSvc.reset();
   });
@@ -52,7 +52,29 @@ describe('searchResultsCtrl', function() {
     expect(scope.start.settings.fieldSpecStr).toBe('id banana');
     expect(localStorageSvc.get('fieldSpecStr')).toEqual(scope.start.settings.fieldSpecStr);
   });
-  
+
+  it('bootstraps fieldSpec arg in URL', function() {
+    var overridingFieldSpec = 'id:banana f:id';
+    locationSvc.lastParams = {solr: 'http://localhost:1234/solr/stuff?q=foo&fl=id banana', fieldSpec: overridingFieldSpec};
+    createController();
+    expect(scope.start.settings.startUrl).toBe(locationSvc.lastParams.solr);
+    expect(localStorageSvc.get('startUrl')).toEqual(scope.start.settings.startUrl);
+    expect(scope.start.settings.searchArgsStr).toContain('q=foo');
+    expect(localStorageSvc.get('searchArgsStr')).toEqual('!' + scope.start.settings.searchArgsStr);
+    expect(scope.start.settings.searchUrl).toBe('http://localhost:1234/solr/stuff');
+    expect(localStorageSvc.get('searchUrl')).toEqual(scope.start.settings.searchUrl);
+    expect(scope.start.settings.fieldSpecStr).toBe(overridingFieldSpec);
+    expect(localStorageSvc.get('fieldSpecStr')).toEqual(scope.start.settings.fieldSpecStr);
+  });
+
+  it('ignores fieldSpec w/o Solr URl', function() {
+    var overridingFieldSpec = 'id:banana f:id';
+    locationSvc.lastParams = {fieldSpec: overridingFieldSpec};
+    createController();
+    expect(scope.start.settings.startUrl).toBe('');
+    expect(scope.start.settings.fieldSpecStr).not.toBe(overridingFieldSpec);
+  });
+
   it('bootstraps submitted URL', function() {
     locationSvc.lastParams = {};
     createController();

--- a/test/spec/services/settingsStoreSvc.js
+++ b/test/spec/services/settingsStoreSvc.js
@@ -4,20 +4,20 @@ describe('Service: settingsStoreSvc', function () {
 
   // load the service's module
   beforeEach(module('splain-app'));
-  
+
   var settingsStoreSvc = null;
   var localStorageSvc = null;
   var locationSvc = null;
 
   var setupSvc = null;
-  
+
   beforeEach(function() {
 
     /* global MockLocalStorageService*/
     /* global MockLocationSvc*/
     localStorageSvc = new MockLocalStorageService();
     locationSvc = new MockLocationSvc();
-    
+
     module(function($provide) {
       $provide.value('localStorageService', localStorageSvc);
       $provide.value('$location', locationSvc);
@@ -29,7 +29,7 @@ describe('Service: settingsStoreSvc', function () {
       });
     };
   });
-  
+
   beforeEach(function() {
     localStorageSvc.reset();
   });
@@ -64,7 +64,7 @@ describe('Service: settingsStoreSvc', function () {
     expect(settings.searchArgsStr).toEqual(testSearchArgsStr);
     expect(settings.whichEngine).toEqual(testWhichEngine);
   });
-  
+
   it('saves updates', function() {
     setupSvc();
     var settings = settingsStoreSvc.settings;
@@ -80,8 +80,19 @@ describe('Service: settingsStoreSvc', function () {
     expect(localStorageSvc.get('fieldSpecStr')).toEqual(testFieldSpecStr);
     expect(localStorageSvc.get('searchArgsStr')).toEqual('!' + testSearchArgsStr);
     expect(localStorageSvc.get('whichEngine')).toEqual(testWhichEngine);
-    expect(locationSvc.lastParams.solr).toEqual(testStartUrl);
-
-
   });
+
+  it('navigates on updates', function() {
+    setupSvc();
+    var settings = settingsStoreSvc.settings;
+    settings.startUrl = testStartUrl;
+    settings.searchUrl = testSearchUrl;
+    settings.fieldSpecStr = testFieldSpecStr;
+    settings.whichEngine = testWhichEngine;
+    settings.searchArgsStr = testSearchArgsStr;
+    settingsStoreSvc.save();
+    expect(locationSvc.lastParams.solr).toEqual(testStartUrl);
+    expect(locationSvc.lastParams.fieldSpec).toEqual(testFieldSpecStr);
+  });
+
 });

--- a/test/spec/services/solrSettingsSvc.js
+++ b/test/spec/services/solrSettingsSvc.js
@@ -4,21 +4,21 @@ describe('Service: solrSettingsSvc', function () {
 
   // load the service's module
   beforeEach(module('splain-app'));
-  
+
   var solrSettingsSvc = null;
   var solrUrlSvc = null;
   beforeEach(inject(function (_solrSettingsSvc_, _solrUrlSvc_) {
     solrSettingsSvc = _solrSettingsSvc_;
     solrUrlSvc = _solrUrlSvc_;
   }));
-  
+
   var stubSettings = function() {
     return {
       startUrl: '',
       whichEngine: '',
       searchUrl: '',
       fieldSpecStr: '',
-      searchArgsStr: ''  
+      searchArgsStr: ''
     };
   };
 
@@ -26,35 +26,35 @@ describe('Service: solrSettingsSvc', function () {
     var settings = stubSettings();
     var startUrl = 'http://localhost:8983/solr/example?q=*:*&fl=title catch_line';
     solrSettingsSvc.fromStartUrl(startUrl, settings);
-    expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');    
+    expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');
     expect(settings.fieldSpecStr).toEqual('title catch_line');
     expect(settings.searchArgsStr).toEqual('q=*:*');
     expect(settings.whichEngine).toEqual(0);
     expect(settings.startUrl).toEqual('http://localhost:8983/solr/example?q=*:*&fl=title catch_line');
   });
-  
+
   it('uses default (*) fieldspec when no fl specified', function() {
     var settings = stubSettings();
     var startUrl = 'http://localhost:8983/solr/example?q=*:*';
     solrSettingsSvc.fromStartUrl(startUrl, settings);
-    expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');    
+    expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');
     expect(settings.fieldSpecStr).toEqual('*');
     expect(settings.searchArgsStr).toEqual('q=*:*');
     expect(settings.whichEngine).toEqual(0);
     expect(settings.startUrl).toEqual('http://localhost:8983/solr/example?q=*:*');
   });
-  
+
   it('uses start URL even with no args', function() {
     var settings = stubSettings();
     var startUrl = 'http://localhost:8983/solr/example';
     solrSettingsSvc.fromStartUrl(startUrl, settings);
-    expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');    
+    expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');
     expect(settings.fieldSpecStr).toEqual('*');
     expect(settings.searchArgsStr).toEqual('q=*:*');
     expect(settings.whichEngine).toEqual(0);
     expect(settings.startUrl).toEqual('http://localhost:8983/solr/example');
   });
-  
+
   it('updates start URL from args updates', function() {
     var settings = stubSettings();
     var startUrl = 'http://localhost:8983/solr/example?q=*:*&fl=title catch_line';
@@ -65,7 +65,7 @@ describe('Service: solrSettingsSvc', function () {
 
     expect(settings.startUrl.indexOf('blah')).not.toEqual(-1);
   });
-  
+
   it('updates start URL from args updates, empty fl', function() {
     var settings = stubSettings();
     var startUrl = 'http://localhost:8983/solr/example?q=*:*';
@@ -83,7 +83,7 @@ describe('Service: solrSettingsSvc', function () {
     var settings = stubSettings();
     var startUrl = 'http://localhost:8983/solr/example?q=*:*&fq=cat:meow&fl=title catch_line';
     solrSettingsSvc.fromStartUrl(startUrl, settings);
-    expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');    
+    expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');
     expect(settings.fieldSpecStr).toEqual('title catch_line');
     expect(settings.searchArgsStr).toEqual('q=*:*\n&fq=cat:meow');
     expect(settings.whichEngine).toEqual(0);
@@ -98,4 +98,27 @@ describe('Service: solrSettingsSvc', function () {
     var startArgs = solrUrlSvc.parseSolrUrl(settings.startUrl).solrArgs;
     expect(startArgs.fl).toEqual(['title sub1 sub2']);
   });
+
+  describe('startURL with fieldSpec', function() {
+    it('fieldSpec no fl', function() {
+      var settings = stubSettings();
+      var startUrl = 'http://localhost:8983/solr/example?q=*:*&fq=cat:meow';
+      var fieldSpec = 'id:banana f:happy';
+      solrSettingsSvc.fromStartUrl(startUrl, settings, fieldSpec);
+      expect(settings.fieldSpecStr).toEqual(fieldSpec);
+      expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');
+      expect(settings.searchArgsStr).toEqual('q=*:*\n&fq=cat:meow');
+    });
+
+    it('fieldSpec overrides fl', function() {
+      var settings = stubSettings();
+      var startUrl = 'http://localhost:8983/solr/example?q=*:*&fq=cat:meow&fl=title catch_line';
+      var fieldSpec = 'id:banana f:happy';
+      solrSettingsSvc.fromStartUrl(startUrl, settings, fieldSpec);
+      expect(settings.searchUrl).toEqual('http://localhost:8983/solr/example');
+      expect(settings.fieldSpecStr).toEqual(fieldSpec);
+      expect(settings.searchArgsStr).toEqual('q=*:*\n&fq=cat:meow');
+    });
+  });
+
 });


### PR DESCRIPTION
So a while back we added a handy feature whereby we updated the hash URL to include the Solr URL being looked at (URLs being passed to URLs, crazy, right?).

This feature is great. But often you manipulate the fieldSpec in splainer to do things like specify which field should be treated as the id field and which field should be computed (ie the new `function:blah` syntax). None of that information is carried along in the original Solr URL. Its splainer-specific configuration.

This PR adds an optional fieldSpec to the splainer URL which will be treated as the fieldSpec when splainer loads.

For example this URL:
http://localhost:9000/#?solr=http:%2F%2Fsolr.quepid.com%2Fsolr%2Fstatedecoded%2Fselect%3Fq%3Dtext:law%26foo%3Dtf('text','law')%26fl%3Did&**fieldSpec=id:id,%20f:foo**

which shows the response of a function query and indicates which field is the Solr unique id.

## Acceptance Criteria
- Navigate to splainer, paste in a Solr URL
- Modify the fieldSpec to change which fields are displayed, or which field is the id, which field is the title, or add a function query
- Open a private browser window
- Paste in URL
- Should see identical looking results between the private browser window and where you started
- fieldSpec should be functionally identical (same title, function, id fields though perhaps they're out of order)