### PR TITLE
Dockerize Splainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:6
+
+COPY . /home/splainer
+WORKDIR /home/splainer
+
+RUN npm install -g grunt-cli && \
+    npm install -g bower && \
+    npm install && \
+    bower install --allow-root
+
+CMD ["grunt","serve"]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,7 +68,7 @@ module.exports = function (grunt) {
       options: {
         port: 9000,
         // Change this to '0.0.0.0' to access the server from outside.
-        hostname: 'localhost',
+        // hostname: 'localhost',
         livereload: 35729
       },
       livereload: {


### PR DESCRIPTION
Created: Dockerfile created using official nodejs docker image as base.

Modified: Gruntfile.js was changed to comment out localhost serving as that won't work in container.  Commenting out the hostname line let's `grunt serve` work on 0.0.0.0 (the default).