### PR TITLE
Bugfix 58 update es default query

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ grunt test
 grunt serve
 ```
 
+Now browse to http://localhost:9000.
+
 To build the project, simply run `grunt dist` to build the static artifacts in the dist/ folder.
 
 ```

--- a/app/scripts/services/settingsStoreSvc.js
+++ b/app/scripts/services/settingsStoreSvc.js
@@ -10,9 +10,7 @@ angular.module('splain-app')
 
     var defaultEsArgs = '!{\n' +
                         '  "query": {\n' +
-                        '    "match": {\n' +
-                        '      "_all": ""\n' +
-                        '    }\n' +
+                        '    "match_all": {}\n' +
                         '  }\n' +
                         '}    ';
 


### PR DESCRIPTION
This is a small fix for #58.   

Tested on 

```
* http://quepid-elasticsearch.dev.o19s.com:9205/tmdb/_search is ES5
* http://quepid-elasticsearch.dev.o19s.com:9206/tmdb/_search is ES6
* http://quepid-elasticsearch.dev.o19s.com:9207/tmdb/_search is ES7
```