### PR TITLE
Link to solr for error output opens a new tab

### DIFF
--- a/app/views/searchResults.html
+++ b/app/views/searchResults.html
@@ -3,7 +3,7 @@
     <img src="images/ajax-loader.gif"><img>
   </div>
   <div ng-show="currSearch.state === currSearch.IN_ERROR" class="alert alert-error">
-    Error with your query. Double check that the URL is correct. <div ng-show="currSearch.engine==='solr'">Try accessing <a href="{{currSearch.linkUrl}}">Solr</a> to troubleshoot the error.</div>
+    Error with your query. Double check that the URL is correct. <div ng-show="currSearch.engine==='solr'">Try accessing <a target="_blank" href="{{currSearch.linkUrl}}">Solr</a> to troubleshoot the error.</div>
     <pre ng-show="currSearch.errorMsg.length > 0">{{currSearch.errorMsg}}</pre>
   </div>
 


### PR DESCRIPTION
Other href attributes in `searchResults.html` include the `_blank` target attribute, but it was missing from the error link.