### PR TITLE
Allow ES explain, fix check of search engine

### DIFF
--- a/app/scripts/controllers/docRow.js
+++ b/app/scripts/controllers/docRow.js
@@ -4,7 +4,8 @@ angular.module('splain-app')
   .controller('DocRowCtrl', [
     '$scope',
     '$uibModal',
-    function DocRowCtrl($scope, $uibModal) {
+    'settingsStoreSvc',
+    function DocRowCtrl($scope, $uibModal, settingsStoreSvc) {
 
       $scope.docRow = {};
       $scope.docRow.snippets = function(doc) {
@@ -28,7 +29,7 @@ angular.module('splain-app')
             },
             canExplainOther: function() {
               var allowedEngines = ['es', 'solr'];
-              return allowedEngines.includes($scope.whichEngine);
+              return allowedEngines.includes(settingsStoreSvc.settings.whichEngine);
             }
           }
         });

--- a/app/scripts/controllers/docRow.js
+++ b/app/scripts/controllers/docRow.js
@@ -27,7 +27,8 @@ angular.module('splain-app')
               return $scope.doc;
             },
             canExplainOther: function() {
-              return $scope.whichEngine === 'solr';
+              var allowedEngines = ['es', 'solr'];
+              return allowedEngines.includes($scope.whichEngine);
             }
           }
         });


### PR DESCRIPTION
Fixes #31 and #73 

Reading whichEngine from scope could read an outdated variable.  By reading from settings we always get the latest variable.