### PR TITLE
Tweak the UX to hide the field list if your url ends in /template

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -84,7 +84,10 @@
               Displayed Fields <span ng-class="{true: 'glyphicon-minus-sign', false: 'glyphicon-plus-sign'}[!devSettingsFields.toggle]" class="glyphicon glyphicon-minus-sign"></span>
             </div>
             <div class="dev-section" ng-show="!devSettingsFields.toggle">
-              <input id="inputFieldSpec" type="text" ng-model="workingSettings.fieldSpecStr" placeholder="Fields you'd like to display" class="form-control"></input>
+              <input id="inputFieldSpec" type="text" ng-show="!currSearch.searcher.isTemplateCall()" ng-model="workingSettings.fieldSpecStr" placeholder="Fields you'd like to display" class="form-control"></input>
+              <span ng-show="currSearch.searcher.isTemplateCall()">
+              Specify fields to view via <code>_source</code> defined in the search template when using ES templates.
+              </span>
             </div>
 
             <div class="dev-header" ng-click="devSettingsArgs.toggle = !devSettingsArgs.toggle">


### PR DESCRIPTION
This exposes what is in https://github.com/o19s/splainer-search/pull/92